### PR TITLE
CdmaLteServiceStateTracker: allow forcing reading eri from xml

### DIFF
--- a/src/java/com/android/internal/telephony/cdma/CdmaLteServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/cdma/CdmaLteServiceStateTracker.java
@@ -455,11 +455,13 @@ public class CdmaLteServiceStateTracker extends CdmaServiceStateTracker {
         if (hasChanged) {
             boolean hasBrandOverride = mUiccController.getUiccCard(getPhoneId()) == null ? false :
                     (mUiccController.getUiccCard(getPhoneId()).getOperatorBrandOverride() != null);
-            if (!hasBrandOverride && (mCi.getRadioState().isOn()) && (mPhone.isEriFileLoaded()) &&
+            boolean forceEriFromXml =
+                    SystemProperties.getBoolean("ro.ril.force_eri_from_xml", false);
+            if ((!hasBrandOverride && (mCi.getRadioState().isOn()) && (mPhone.isEriFileLoaded()) &&
                     (!isRatLte(mSS.getRilVoiceRadioTechnology()) ||
                             mPhone.getContext().getResources().getBoolean(com.android.internal.R.
                                     bool.config_LTE_eri_for_network_name)) &&
-                                    !mIsSubscriptionFromRuim) {
+                                    !mIsSubscriptionFromRuim) || forceEriFromXml) {
                 // Only when CDMA is in service, ERI will take effect
                 String eriText = mSS.getOperatorAlphaLong();
                 // Now the CDMAPhone sees the new ServiceState so it can get the


### PR DESCRIPTION
- Some devices rely on eri.xml for their cdma text display and
  must be forced to use it. Not reading from eri.xml results in
  weird carrier display like NAM1 when on a cdma data network

Change-Id: I73cbedafda912e52817d57e791bf57f8fb32ab48
