### PR TITLE
Store correct IMSI when retreived from SIMRecords and use it for Ruim…

### DIFF
--- a/src/java/com/android/internal/telephony/uicc/RuimRecords.java
+++ b/src/java/com/android/internal/telephony/uicc/RuimRecords.java
@@ -41,6 +41,7 @@ import com.android.internal.telephony.SubscriptionController;
 import com.android.internal.telephony.cdma.sms.UserData;
 import com.android.internal.telephony.uicc.IccCardApplicationStatus.AppType;
 import com.android.internal.util.BitwiseInputStream;
+import com.android.internal.telephony.uicc.UICCConfig;
 
 /**
  * {@hide}
@@ -257,6 +258,17 @@ public final class RuimRecords extends IccRecords {
     public String getOperatorNumeric() {
         if (mImsi == null) {
             return null;
+        }
+
+        if (SystemProperties.getBoolean("ro.telephony.get_imsi_from_sim", false)) {
+           String imsi = mParentApp.getUICCConfig().getImsi();
+           int mnclength = mParentApp.getUICCConfig().getMncLength();
+
+           // If we are LTE over CDMA (Verizon), then pull the correct info from SIMRecords
+            if (imsi != null) {
+                log("Overriding with Operator Numeric: " + imsi.substring(0, 3 + mnclength));
+                return imsi.substring(0, 3 + mnclength);
+            }
         }
 
         if (mMncLength != UNINITIALIZED && mMncLength != UNKNOWN) {

--- a/src/java/com/android/internal/telephony/uicc/SIMRecords.java
+++ b/src/java/com/android/internal/telephony/uicc/SIMRecords.java
@@ -34,6 +34,7 @@ import com.android.internal.telephony.SubscriptionController;
 import com.android.internal.telephony.gsm.SimTlv;
 import com.android.internal.telephony.uicc.IccCardApplicationStatus.AppState;
 import com.android.internal.telephony.uicc.IccCardApplicationStatus.AppType;
+import com.android.internal.telephony.uicc.UICCConfig;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -245,6 +246,8 @@ public class SIMRecords extends IccRecords {
         mTelephonyManager.setSimOperatorNumericForPhone(mParentApp.getPhoneId(), "");
         mTelephonyManager.setSimOperatorNameForPhone(mParentApp.getPhoneId(), "");
         mTelephonyManager.setSimCountryIsoForPhone(mParentApp.getPhoneId(), "");
+        mParentApp.getUICCConfig().setImsi(mImsi);
+        mParentApp.getUICCConfig().setMncLength(mMncLength);
 
         // recordsRequested is set to false indicating that the SIM
         // read requests made so far are not valid. This is set to
@@ -681,6 +684,15 @@ public class SIMRecords extends IccRecords {
                     }
                 }
 
+                mParentApp.getUICCConfig().setImsi(mImsi);
+                if (mMncLength == UNKNOWN || mMncLength == UNINITIALIZED) {
+                    // We need to default to something that seems common
+                    mParentApp.getUICCConfig().setMncLength(3);
+                } else {
+                    mParentApp.getUICCConfig().setMncLength(mMncLength);
+                }
+
+
                 if (mMncLength != UNKNOWN && mMncLength != UNINITIALIZED) {
                     log("update mccmnc=" + mImsi.substring(0, 3 + mMncLength));
                     // finally have both the imsi and the mncLength and can parse the imsi properly
@@ -905,7 +917,10 @@ public class SIMRecords extends IccRecords {
                     } else if (mMncLength != 2 && mMncLength != 3) {
                         mMncLength = UNINITIALIZED;
                         log("setting5 mMncLength=" + mMncLength);
+                    } else {
+                        mParentApp.getUICCConfig().setMncLength(mMncLength);
                     }
+
                 } finally {
                     if (((mMncLength == UNINITIALIZED) || (mMncLength == UNKNOWN) ||
                             (mMncLength == 2)) && ((mImsi != null) && (mImsi.length() >= 6))) {

--- a/src/java/com/android/internal/telephony/uicc/UICCConfig.java
+++ b/src/java/com/android/internal/telephony/uicc/UICCConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.telephony.uicc;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.telephony.Rlog;
+
+/**
+ * A class that stores various UICC Settings/values.
+ * @hide
+ */
+public final class UICCConfig
+{
+    private final String PREFERENCE_NAME = "UICCConfig";
+    private final String TAG = "UICCConfig";
+    private final boolean LOG_DEBUG = false;
+
+    private String mImsi;
+    private int mMncLength;
+
+    /**
+     * A method to get the stored Imsi.
+     * @hide
+     */
+    public String getImsi() {
+        if (mImsi == null) {
+            logd("Getting IMSI: null");
+        } else {
+            logd("Getting IMSI: " + mImsi);
+        }
+        return mImsi;
+    }
+
+    /**
+     * A method to set the stored Imsi.
+     * @hide
+     */
+    public void setImsi(String lImsi) {
+        logd("Setting IMSI: " + lImsi);
+        mImsi = lImsi;
+    }
+
+    /**
+     * A method to get the stored MncLength.
+     * @hide
+     */
+    public int getMncLength() {
+        logd("Getting MncLength: " + Integer.toString(mMncLength));
+        return mMncLength;
+    }
+
+    /**
+     * A method to set the stored MncLength.
+     * @hide
+     */
+    public void setMncLength(int lMncLength) {
+        logd("Setting MncLength: " + Integer.toString(lMncLength));
+        mMncLength = lMncLength;
+    }
+
+    private void logd(String sLog) {
+        if (LOG_DEBUG) {
+            Rlog.d(TAG, sLog);
+        }
+    }
+
+    private void loge(String sLog)
+    {
+        Rlog.e(TAG, sLog);
+    }
+
+}

--- a/src/java/com/android/internal/telephony/uicc/UiccCard.java
+++ b/src/java/com/android/internal/telephony/uicc/UiccCard.java
@@ -84,6 +84,7 @@ public class UiccCard {
     private RadioState mLastRadioState =  RadioState.RADIO_UNAVAILABLE;
     private UiccCarrierPrivilegeRules mCarrierPrivilegeRules;
     private boolean m3GPPAppActivated, m3GPP2AppActivated;
+    private UICCConfig mUICCConfig = null;
 
     private RegistrantList mAbsentRegistrants = new RegistrantList();
     private RegistrantList mCarrierPrivilegeRegistrants = new RegistrantList();
@@ -129,6 +130,7 @@ public class UiccCard {
             mCatService = null;
             mUiccApplications = null;
             mCarrierPrivilegeRules = null;
+            mUICCConfig = null;
         }
     }
 
@@ -144,6 +146,8 @@ public class UiccCard {
             mCi = ci;
 
             //update applications
+            if (mUICCConfig == null)
+                mUICCConfig = new UICCConfig();
             if (DBG) log(ics.mApplications.length + " applications");
             for ( int i = 0; i < mUiccApplications.length; i++) {
                 if (mUiccApplications[i] == null) {
@@ -678,6 +682,10 @@ public class UiccCard {
             }
         }
         return null;
+    }
+
+    public UICCConfig getUICCConfig() {
+        return mUICCConfig;
     }
 
     private void log(String msg) {

--- a/src/java/com/android/internal/telephony/uicc/UiccCardApplication.java
+++ b/src/java/com/android/internal/telephony/uicc/UiccCardApplication.java
@@ -31,6 +31,7 @@ import com.android.internal.telephony.uicc.IccCardApplicationStatus.AppType;
 import com.android.internal.telephony.uicc.IccCardApplicationStatus.PersoSubState;
 import com.android.internal.telephony.uicc.IccCardStatus.PinState;
 import com.android.internal.telephony.SubscriptionController;
+import com.android.internal.telephony.uicc.UICCConfig;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -882,6 +883,10 @@ public class UiccCardApplication {
 
     protected UiccCard getUiccCard() {
         return mUiccCard;
+    }
+
+    public UICCConfig getUICCConfig() {
+        return mUiccCard.getUICCConfig();
     }
 
     private void log(String msg) {


### PR DESCRIPTION
…Records

Stock stores the IMSI gathered with SIMRecords and uses that value when
RuimRecords wants to get the APN/operator number.

Set System prop "ro.telephony.get_imsi_from_sim=true" to enable this function

Change-Id: I9597002c7472c1ed93826f3d582c3155956c472c
